### PR TITLE
feat: monorepo support

### DIFF
--- a/lua/goto-alias/init.lua
+++ b/lua/goto-alias/init.lua
@@ -7,6 +7,7 @@ local M = {}
 
 M.is_nuxt_project = false
 M.original_definition = vim.lsp.buf.definition
+M.nuxt_directory_path = ""
 
 local default_check_directories = { "" }
 
@@ -15,9 +16,12 @@ M.setup = function(opts)
 
 	local check_directories = vim.list_extend(default_check_directories, opts.check_directories or {})
 
-	for _, dir in ipairs(check_directories) do
-		if vim.fn.isdirectory(vim.loop.cwd() .. dir .. "/.nuxt") == 1 then
+	for _, directory in ipairs(check_directories) do
+		if vim.fn.isdirectory(vim.loop.cwd() .. directory .. "/.nuxt") == 1 then
 			M.is_nuxt_project = true
+			if directory ~= "" then
+				M.nuxt_directory_path = string.sub(directory, 2)
+			end
 		end
 	end
 
@@ -43,10 +47,10 @@ M.watch = function()
 
 		if string.find(file, "components.d.ts") then
 			vim.api.nvim_buf_delete(0, { force = false })
-			vim.cmd("edit apps/web/" .. path)
+			vim.cmd("edit " .. M.nuxt_directory_path .. "/" .. path)
 		elseif string.find(line, "components.d.ts") then
 			vim.cmd("cclose")
-			vim.cmd("edit apps/web/" .. path)
+			vim.cmd("edit " .. M.nuxt_directory_path .. "/" .. path)
 		end
 	end, 100)
 end

--- a/lua/goto-alias/init.lua
+++ b/lua/goto-alias/init.lua
@@ -22,6 +22,7 @@ M.setup = function(opts)
 			if directory ~= "" then
 				M.nuxt_directory_path = string.sub(directory, 2)
 			end
+			break
 		end
 	end
 

--- a/lua/goto-alias/init.lua
+++ b/lua/goto-alias/init.lua
@@ -1,18 +1,22 @@
 --TODO:
 --tests
 --does .nuxt directory detection using string.concat have better preformance?
---newly created components do not seem to workb
+--newly created components do not seem to work
 
 local M = {}
 
 M.is_nuxt_project = false
 M.original_definition = vim.lsp.buf.definition
 
-M.setup = function()
-	local dirList = vim.fn.systemlist("ls -a")
+local default_check_directories = { "" }
 
-	for _, dirname in ipairs(dirList) do
-		if dirname == ".nuxt" then
+M.setup = function(opts)
+	opts = opts or {}
+
+	local check_directories = vim.list_extend(default_check_directories, opts.check_directories or {})
+
+	for _, dir in ipairs(check_directories) do
+		if vim.fn.isdirectory(vim.loop.cwd() .. dir .. "/.nuxt") == 1 then
 			M.is_nuxt_project = true
 		end
 	end
@@ -38,7 +42,11 @@ M.watch = function()
 		local file = vim.fn.expand("%")
 
 		if string.find(file, "components.d.ts") then
-			vim.cmd("edit " .. path)
+			vim.api.nvim_buf_delete(0, { force = false })
+			vim.cmd("edit apps/web/" .. path)
+		elseif string.find(line, "components.d.ts") then
+			vim.cmd("cclose")
+			vim.cmd("edit apps/web/" .. path)
 		end
 	end, 100)
 end

--- a/lua/goto-alias/init.lua
+++ b/lua/goto-alias/init.lua
@@ -9,7 +9,7 @@ M.is_nuxt_project = false
 M.original_definition = vim.lsp.buf.definition
 M.nuxt_directory_path = ""
 
-local default_check_directories = { "" }
+local default_check_directories = { "/apps/web", "/apps/nuxt", "/apps/frontend", "/apps/website" }
 
 M.setup = function(opts)
 	opts = opts or {}
@@ -36,22 +36,52 @@ M.setup = function(opts)
 			vim.lsp.buf.definition = M.watch
 		end,
 	})
+
+	-- this is in the original repo. whyyy???
+	-- - maybe for when you change repo without closing neovim?
+	-- M.is_nuxt_project = false
+	-- M.original_definition = vim.lsp.buf.definition
+	-- M.nuxt_directory_path = ""
 end
 
 M.watch = function()
 	M.original_definition()
+
+	if not M.is_nuxt_project then
+		return
+	end
 
 	vim.defer_fn(function()
 		local line = vim.fn.getline(".")
 		local path = string.match(line, '".-/(.-)"')
 		local file = vim.fn.expand("%")
 
-		if string.find(file, "components.d.ts") then
-			vim.api.nvim_buf_delete(0, { force = false })
-			vim.cmd("edit " .. M.nuxt_directory_path .. "/" .. path)
-		elseif string.find(line, "components.d.ts") then
-			vim.cmd("cclose")
-			vim.cmd("edit " .. M.nuxt_directory_path .. "/" .. path)
+		local auto_import_files = { "components.d.ts", "imports.d.ts" }
+
+		for _, auto_import_file in ipairs(auto_import_files) do
+			if string.find(file, auto_import_file) then
+				vim.api.nvim_buf_delete(0, { force = false })
+				vim.cmd("edit " .. M.nuxt_directory_path .. "/" .. path)
+				break
+			elseif string.find(line, auto_import_file) then
+				if string.find(line, "stores") then
+					local storePath = string.match(line, "'.-/(.-)'")
+					vim.cmd("cclose")
+					vim.cmd("edit " .. M.nuxt_directory_path .. "/stores/" .. storePath .. ".ts")
+				elseif string.find(line, "composables") then
+					local composablePath = string.match(line, "'.-/(.-)'")
+					vim.cmd("cclose")
+					vim.cmd("edit " .. M.nuxt_directory_path .. "/composables/" .. composablePath .. ".ts")
+				elseif string.find(line, "utils") then
+					local utilsPath = string.match(line, "'.-/(.-)'")
+					vim.cmd("cclose")
+					vim.cmd("edit " .. M.nuxt_directory_path .. "/utils/" .. utilsPath .. ".ts")
+				else
+					vim.cmd("cclose")
+					vim.cmd("edit " .. M.nuxt_directory_path .. "/" .. path)
+				end
+				break
+			end
 		end
 	end, 100)
 end

--- a/lua/goto-alias/init.lua
+++ b/lua/goto-alias/init.lua
@@ -5,11 +5,12 @@
 
 local M = {}
 
-M.is_nuxt_project = false
 M.original_definition = vim.lsp.buf.definition
+M.is_nuxt_project = false
 M.nuxt_directory_path = ""
+M.it_worked = false
 
-local default_check_directories = { "/apps/web", "/apps/nuxt", "/apps/frontend", "/apps/website" }
+local default_check_directories = { "", "/apps/web", "/apps/nuxt", "/apps/frontend", "/apps/website" }
 
 M.setup = function(opts)
 	opts = opts or {}
@@ -44,6 +45,46 @@ M.setup = function(opts)
 	-- M.nuxt_directory_path = ""
 end
 
+local redirect_if_auto_import = function()
+	if M.it_worked then
+		return
+	end
+
+	local line = vim.fn.getline(".")
+	local path = string.match(line, '".-/(.-)"')
+	local file = vim.fn.expand("%")
+
+	local auto_import_files = { "components.d.ts", "imports.d.ts" }
+
+	for _, auto_import_file in ipairs(auto_import_files) do
+		if string.find(file, auto_import_file) then
+			vim.api.nvim_buf_delete(0, { force = false })
+			vim.cmd("edit " .. M.nuxt_directory_path .. "/" .. path)
+			M.it_worked = true
+			break
+		elseif string.find(line, auto_import_file) then
+			if string.find(line, "stores") then
+				local storePath = string.match(line, "'.-/(.-)'")
+				vim.cmd("cclose")
+				vim.cmd("edit " .. M.nuxt_directory_path .. "/stores/" .. storePath .. ".ts")
+			elseif string.find(line, "composables") then
+				local composablePath = string.match(line, "'.-/(.-)'")
+				vim.cmd("cclose")
+				vim.cmd("edit " .. M.nuxt_directory_path .. "/composables/" .. composablePath .. ".ts")
+			elseif string.find(line, "utils") then
+				local utilsPath = string.match(line, "'.-/(.-)'")
+				vim.cmd("cclose")
+				vim.cmd("edit " .. M.nuxt_directory_path .. "/utils/" .. utilsPath .. ".ts")
+			else
+				vim.cmd("cclose")
+				vim.cmd("edit " .. M.nuxt_directory_path .. "/" .. path)
+			end
+			M.it_worked = true
+			break
+		end
+	end
+end
+
 M.watch = function()
 	M.original_definition()
 
@@ -51,39 +92,14 @@ M.watch = function()
 		return
 	end
 
+	-- retry with exponential backoff
+	vim.defer_fn(redirect_if_auto_import, 10)
+	vim.defer_fn(redirect_if_auto_import, 50)
+	vim.defer_fn(redirect_if_auto_import, 100)
+	vim.defer_fn(redirect_if_auto_import, 1000)
 	vim.defer_fn(function()
-		local line = vim.fn.getline(".")
-		local path = string.match(line, '".-/(.-)"')
-		local file = vim.fn.expand("%")
-
-		local auto_import_files = { "components.d.ts", "imports.d.ts" }
-
-		for _, auto_import_file in ipairs(auto_import_files) do
-			if string.find(file, auto_import_file) then
-				vim.api.nvim_buf_delete(0, { force = false })
-				vim.cmd("edit " .. M.nuxt_directory_path .. "/" .. path)
-				break
-			elseif string.find(line, auto_import_file) then
-				if string.find(line, "stores") then
-					local storePath = string.match(line, "'.-/(.-)'")
-					vim.cmd("cclose")
-					vim.cmd("edit " .. M.nuxt_directory_path .. "/stores/" .. storePath .. ".ts")
-				elseif string.find(line, "composables") then
-					local composablePath = string.match(line, "'.-/(.-)'")
-					vim.cmd("cclose")
-					vim.cmd("edit " .. M.nuxt_directory_path .. "/composables/" .. composablePath .. ".ts")
-				elseif string.find(line, "utils") then
-					local utilsPath = string.match(line, "'.-/(.-)'")
-					vim.cmd("cclose")
-					vim.cmd("edit " .. M.nuxt_directory_path .. "/utils/" .. utilsPath .. ".ts")
-				else
-					vim.cmd("cclose")
-					vim.cmd("edit " .. M.nuxt_directory_path .. "/" .. path)
-				end
-				break
-			end
-		end
-	end, 100)
+		M.it_worked = false
+	end, 1100)
 end
 
 return M


### PR DESCRIPTION
Closes #3 

## Changes (i may have gone out of scope)

- You can now pass in opts.check_directories in your plugin config to check for a .nuxt folder nested in your cwd
- Fixed a bug where I would goto definition on a component, but instead of components.d.ts it gave me a quickfix list with 2 different references. Then it wouldn't find components.d.ts in the current file and stop working
- Nuxt-goto now automatically closes the components.d.ts file automatically so it feels like you're directly opening the reference. Same with quickfix list. This is how I want the plugin to work, but if you don't like it we can make it an option

How I configured nuxt-goto in lazy.nvim when testing:
```
{
    dir = "~/Documents/Koding/neovim-plugins/nuxt-goto.nvim",
    ft = "vue",
    event = "BufEnter",
    -- opts is completely optional
    opts = {
        -- format for the path. Eg start with "/" end without "/". Is very important
        check_directories = { "/apps/web" },
    },
}
```

This worked great for me using turborepo, but I havent tested on a normal nuxt project. It should work though because we check if cwd + /.nuxt is a directory which it should be. 

I don't know how you pass options in packer so I didn't wanna edit the readme but since the plugin will still work as normal it shouldn't be a problem

If you've stopped maintaining this or don't wanna test my PR I'll just use my fork, but would be cool if you would check it out